### PR TITLE
Update security-incident-update.md

### DIFF
--- a/api-reference/v1.0/api/security-incident-update.md
+++ b/api-reference/v1.0/api/security-incident-update.md
@@ -48,7 +48,7 @@ PATCH /security/incidents/{incidentId}
 |assignedTo|String|Owner of the incident, or null if no owner is assigned. Free editable text.|
 |classification|microsoft.graph.security.alertClassification|The specification for the incident. Possible values are: `unknown`, `falsePositive`, `truePositive`, `informationalExpectedActivity`, `unknownFutureValue`.|
 |determination|microsoft.graph.security.alertDetermination|Specifies the determination of the incident. Possible values are: `unknown`, `apt`, `malware`, `securityPersonnel`, `securityTesting`, `unwantedSoftware`, `other`, `multiStagedAttack`, `compromisedUser`, `phishing`, `maliciousUserActivity`, `notMalicious`, `notEnoughDataToValidate`, `confirmedUserActivity`, `lineOfBusinessApplication`, `unknownFutureValue`.|
-|status|microsoft.graph.security.incidentStatus|The status of the incident. Possible values are: `active`, `resolved`, `redirected`, `unknownFutureValue`.|
+|status|microsoft.graph.security.incidentStatus|The status of the incident. Possible values are: `active`, `resolved`, `inProgress`, `unknownFutureValue`.|
 |customTags|String collection|Array of custom tags associated with an incident.|
 
 


### PR DESCRIPTION
Removing 'redirected' status.
Adding 'inProgress' status.

'redirected' status is not supported in M365D incidents. If you PATCH this status value for an incident, it will cause users not able to open it from M365 security portal.

M365D incidents have the 3 status below.

- active,
- inProgress
- resolved